### PR TITLE
Fix npmjs.com not seeing the repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/markjm/eslint-import-resolver-enhanced-resolve.git"
+    "url": "git+https://github.com/markjm/eslint-import-resolver-enhanced-resolve.git"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
At least, I assume this is why it doesn't show up on the site. Took me a while to find this repo.